### PR TITLE
Fix approval bug

### DIFF
--- a/src/controllers/product.js
+++ b/src/controllers/product.js
@@ -312,6 +312,13 @@ const approveRequest = async (req, res) => {
         message: 'Product not found',
       });
     }
+    
+    if (String(product.publisher) !== req.user.userId) {
+      return res.status(401).json({
+        message: 'You are not authorized to perform this action',
+      });
+    }
+    
     const requesterInOrders = product.orderRequests.includes(
       req.params.requesterId
     );


### PR DESCRIPTION
## Fixes a bug that allowed anyone to approve anyone's requests.

### So technically, a user that just requested someone's product can approve it right away.
### Here, you can see that the request approver and receiver are the same user:
![Screenshot from 2022-08-28 16-37-50](https://user-images.githubusercontent.com/102853969/187076866-5b3adc27-2d27-4e50-b51a-3e337cf79bf3.png)

Edit: The image is only to demonstrate the bug. Emails still look normal when this bug is invoked:
![Screenshot from 2022-08-28 17-01-44](https://user-images.githubusercontent.com/102853969/187078122-936360f8-8928-4015-8586-297d68d9abbc.png)

